### PR TITLE
Add Jest and tests for helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
@@ -29,7 +29,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "sass": "^1.83.4",
     "vite": "^6.2.0",
-    "vite-plugin-eslint": "^1.8.1"
+    "vite-plugin-eslint": "^1.8.1",
+    "jest": "^29.7.0"
   },
   "description": ""
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -68,5 +68,11 @@ function getProjectById(id) {
 }
 
 // Export (if you use ES modules). Or just keep them in global scope.
-window.getAllProjects = getAllProjects;
-window.getProjectById = getProjectById;
+if (typeof window !== 'undefined') {
+  window.getAllProjects = getAllProjects;
+  window.getProjectById = getProjectById;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getAllProjects, getProjectById };
+}

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,22 @@
+const { getAllProjects, getProjectById } = require('../scripts/helpers.js');
+
+describe('helpers', () => {
+  test('getAllProjects returns all projects', () => {
+    const projects = getAllProjects();
+    expect(Array.isArray(projects)).toBe(true);
+    expect(projects.length).toBe(2);
+    expect(projects[0].id).toBe(1);
+    expect(projects[1].id).toBe(2);
+  });
+
+  test('getProjectById returns correct project', () => {
+    const project = getProjectById(1);
+    expect(project).toBeDefined();
+    expect(project.title).toBe('Webcam Painter (Dartmouth CS10)');
+  });
+
+  test('getProjectById returns undefined for invalid id', () => {
+    const project = getProjectById(999);
+    expect(project).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and configure npm test script
- expose helper functions for Node and update helpers.js
- add basic tests for `getAllProjects` and `getProjectById`

## Testing
- `npm test` *(fails: jest: not found)*